### PR TITLE
show the correct rate calculation when fiat-crypto direction is used

### DIFF
--- a/package/src/BuyCryptoView/BodyBuyCrypto.tsx
+++ b/package/src/BuyCryptoView/BodyBuyCrypto.tsx
@@ -40,7 +40,7 @@ function mapGatewaySelectedToPicker(selectedGateway?: GatewayRateOption): (IGate
   return {
       name: selectedGateway.name,
       icon: selectedGateway.icon || "",
-      rate: selectedGateway.rate ? selectedGateway.rate.toLocaleString() : ""
+      rate: selectedGateway.rate
   }
 }
 
@@ -198,6 +198,7 @@ const BodyBuyCrypto: React.FC<BodyBuyCryptoProps> = (props) => {
               openMoreOptions={onBuyCrypto}
               isLoading={collected.isCalculatingAmount}
               isInitialLoading={isGatewayInitialLoading}
+              amountInCrypto={!!collected.amountInCrypto}
             />
           )}
 

--- a/package/src/BuyCryptoView/GatewayIndicator/GatewayIndicator.models.tsx
+++ b/package/src/BuyCryptoView/GatewayIndicator/GatewayIndicator.models.tsx
@@ -5,10 +5,11 @@ export interface GatewayIndicatorProps {
     selectedGateway?: IGatewaySelected;
     isLoading: boolean;
     isInitialLoading: boolean;
+    amountInCrypto: boolean;
 }
 
 export interface IGatewaySelected {
     name: string;
-    rate: string;
+    rate: number | undefined;
     icon: string;
 }

--- a/package/src/BuyCryptoView/GatewayIndicator/GatewayIndicator.module.css
+++ b/package/src/BuyCryptoView/GatewayIndicator/GatewayIndicator.module.css
@@ -58,6 +58,7 @@
     color: #7C7D82;
     margin: 4px 0px;
     text-align: right;
+    word-break: break-all;
 }
 
 .sk-option-body {

--- a/package/src/BuyCryptoView/GatewayIndicator/GatewayIndicator.tsx
+++ b/package/src/BuyCryptoView/GatewayIndicator/GatewayIndicator.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { GatewayIndicatorProps } from './GatewayIndicator.models';
 import arrowDownIcon from "./../../icons/arrow-down.svg";
 import styles from "./GatewayIndicator.module.css";
@@ -20,7 +20,25 @@ const Skeleton: React.FC = () => {
     </div>);
 }
 
+const determineRate = (amountInCrypto:boolean, oneDirectionRate: number|undefined) => {
+    if(!oneDirectionRate) return 0;
+    
+    const format = (n:number) => n.toLocaleString(undefined, {maximumFractionDigits: 5});
+
+    if(!amountInCrypto) {
+        return format(oneDirectionRate);
+    }
+
+    return format(1 / oneDirectionRate)
+}
+
 const GatewayIndicator: React.FC<GatewayIndicatorProps> = (props: GatewayIndicatorProps) => {
+    const [rate, setRate] = useState(determineRate(props.amountInCrypto, props.selectedGateway?.rate));
+
+    useEffect(() => {
+        setRate(determineRate(props.amountInCrypto, props.selectedGateway?.rate));
+    }, [props.amountInCrypto, props.selectedGateway?.rate]);
+
     if (props.isInitialLoading || !props.selectedGateway) return <Skeleton />;
     
     if(props.isLoading) {
@@ -42,7 +60,7 @@ const GatewayIndicator: React.FC<GatewayIndicatorProps> = (props: GatewayIndicat
             </div>
         </div>
         <div className={styles["option-info"]}>
-            1 {props.unitCrypto} ≈ {props.selectedGateway.rate} {props.unitFiat}
+            1 {props.unitCrypto} ≈ {rate} {props.unitFiat}
             <br />Includes all feees
         </div>
     </div>);


### PR DESCRIPTION
When fiat-crypto rate is showed the rate used by gateway indicator to show 1 crypto ~ n fiat should be the rate.
When crypto-fiat rate is showed the rate used by gateway indicator to show 1 crypto ~ n fiat should be 1/rate.

![image](https://user-images.githubusercontent.com/93923374/145381027-7c147282-b0e0-4605-9e15-7795ff54932e.png)

Note:
as you switch between fiat-> crypto OR crypto->fiat (using the arrow button), you may notice the rate changes. This is correct, because there are different fees included based on what we use (fiat->crypto or crypto-fiat). These fees are included in the rate. So:  
r1 = rate + (crypto-fiat fees) => 1 BTC = 1/r1 USD
r2 = rate + (fiat-crypto fees) => 1 BTC = 1 r2 USD