### PR TITLE
Features/29/239 mock possible form view steps

### DIFF
--- a/iframe/package.json
+++ b/iframe/package.json
@@ -16,6 +16,7 @@
     "start": "react-scripts start",
     "start:prod": "export REACT_APP_STAGE=prod&&npm start",
     "start:demo": "export REACT_APP_STAGE=demo&&npm start",
+    "start:demo-win": "set REACT_APP_STAGE=demo&&npm start",
     "start:local": "set PORT=3001&&npm start",
     "build": "react-scripts build",
     "build:dev": "react-scripts build",

--- a/iframe/src/mocks/handlers.ts
+++ b/iframe/src/mocks/handlers.ts
@@ -4,7 +4,10 @@ import { ratesAllParams/* , ratesAllUnavailable */ } from './responses/rates'
 import CCPro from './responses/steps/Cryptocoin.pro'
 import Moonpay from './responses/steps/Moonpay'
 import Wyre from './responses/steps/Wyre'
+import TestGateway from './responses/steps/TestGateway/steps';
 import { BASE_API } from './constants'
+
+const gatewayMap:{[key:string]: object } = { CCPro, Wyre, TestGateway };
 
 let moonpayKYCStepsCount = 0
 
@@ -247,5 +250,16 @@ export const handlers = [
             ctx.status(200),
             ctx.json({ type: "completed" })
         )
-    })
+    }),
+    rest.post(`${BASE_API}/GoTo/*`, async (req, res, ctx) => {
+        const gatewayName = req.url.pathname.split('/')[2];
+        const gateway = gatewayMap[gatewayName] as { getNextStep: (value:string) => any };
+        const stepName = req.url.pathname.split('/')[3];
+        const nextStep = gateway ? gateway.getNextStep(stepName) : { type: 'completed' };
+
+        return res(
+            ctx.status(200),
+            ctx.json(nextStep)
+        )
+    }),
 ]

--- a/iframe/src/mocks/responses/steps/TestGateway/possibleFomStepFields.ts
+++ b/iframe/src/mocks/responses/steps/TestGateway/possibleFomStepFields.ts
@@ -153,6 +153,12 @@ const allFormFields = [
     ]
   },
   {
+    type: "string",
+    name: "state",
+    humanName: "Select state",
+    required: false,
+  },
+  {
     type: "choice",
     humanName: "Type of identity document (choice)",
     name: "documentType",
@@ -160,13 +166,6 @@ const allFormFields = [
         "Identity card",
         "Passport"
     ],
-  },
-  {
-    type: "string",
-    name: "state",
-    humanName: "State",
-    hint: "Only required if your address is in the US",
-    required: false,
   },
   ...creditCardFormFieldsGroup,
   ...phoneNumberFormFieldsGroup,

--- a/iframe/src/mocks/responses/steps/TestGateway/possibleFomStepFields.ts
+++ b/iframe/src/mocks/responses/steps/TestGateway/possibleFomStepFields.ts
@@ -1,0 +1,225 @@
+import { BASE_API } from "../../../constants";
+
+const creditCardFormFieldsGroup = [
+  {
+    type: "string",
+    name: "ccNumber",
+    humanName: "Credit Card Number",
+  },
+  {
+    type: "string",
+    name: "ccMonth",
+    humanName: "Credit Card Expiration Month",
+  },
+  {
+    type: "string",
+    name: "ccYear",
+    humanName: "Credit Card Expiration Year",
+  },
+  {
+    type: "string",
+    name: "ccCVV",
+    humanName: "Credit Card CVV",
+  },
+];
+
+const phoneNumberFormFieldsGroup = [
+  {
+    type: "integer",
+    name: "phoneCountryCode",
+    humanName: "Phone country code",
+  },
+  {
+    type: "integer",
+    name: "phoneNumber",
+    humanName: "Phone number",
+    hint:
+      "Landlines and VoIP are not accepted. Please use a mobile phone number",
+  },
+];
+
+const personalInfoFields = [
+  {
+    type: "string",
+    name: "firstName",
+    humanName: "First name",
+  },
+  {
+    type: "string",
+    name: "lastName",
+    humanName: "Last name",
+  },
+  {
+    type: "string",
+    name: "street",
+    humanName: "Street",
+  },
+  {
+    type: "string",
+    name: "town",
+    humanName: "City",
+  },
+  {
+    type: "string",
+    name: "postCode",
+    humanName: "Postal Code",
+  },
+  {
+    type: "date",
+    name: "dateOfBirth",
+    humanName: "Date of Birth",
+    data: [
+      {
+        type: "integer",
+        humanName: "Day",
+        name: "day",
+      },
+      {
+        type: "integer",
+        humanName: "Month",
+        name: "month",
+      },
+      {
+        type: "integer",
+        humanName: "Year",
+        name: "year",
+      },
+    ],
+  },
+  {
+    type: "string",
+    name: "email",
+    humanName: "Email",
+    hint: "Hint for email field.",
+  },
+  {
+    type: "string",
+    name: "identityDocumentLastName",
+    humanName: "Last name as on the identity document",
+  },
+];
+
+const allFormFields = [
+  {
+    type: "string",
+    name: "cryptocurrencyAddress",
+    humanName: "Cryptocurrency wallet address",
+    hint: "This is a test hint for cypto address",
+  },
+  {
+    type: "string",
+    name: "verifyCreditCard",
+    humanName: "Credit Card verification code",
+    hint:
+      "For the time being, most likely I'm not visible because I'm replaced by a text in the frontend!",
+  },
+  {
+    type: "string",
+    name: "verifyPhoneCode",
+    humanName: "Phone verification code",
+    hint: "A verification code was sent to your phone number. Fill it in here.",
+  },
+  {
+    type: "string",
+    name: "verifyEmailCode",
+    humanName: "Email verification code",
+    hint:
+      "This is a test hint for email code which here is required on purpose",
+    isRequired: true,
+  },
+  {
+    type: "select",
+    name: "name for select",
+    humanName: "Select's label",
+    hint: "Select's hint (is required on purpose)",
+    options: [
+      { humanName: "Test option #1", value: "#1" },
+      { humanName: "Test option #2", value: "#2" },
+      { humanName: "Test option #3", value: "#3" },
+    ]
+  },
+  {
+    name: "country",
+    humanName: "Select country",
+    type: "select",
+    placeholder: "A placeholder",
+    options: [
+      { humanName: "Algeria", value: "DZ" },
+      { humanName: "Argentina", value: "AR" },
+      { humanName: "Australia", value: "AU" },
+      { humanName: "United Kingdom", value: "GB" },
+      { humanName: "United States of America", value: "US" },
+      { humanName: "Vietnam", value: "VN" },
+    ]
+  },
+  {
+    type: "choice",
+    humanName: "Type of identity document (choice)",
+    name: "documentType",
+    options: [
+        "Identity card",
+        "Passport"
+    ],
+  },
+  {
+    type: "string",
+    name: "state",
+    humanName: "State",
+    hint: "Only required if your address is in the US",
+    required: false,
+  },
+  ...creditCardFormFieldsGroup,
+  ...phoneNumberFormFieldsGroup,
+  ...personalInfoFields,
+  {
+    type: "string",
+    name: "cryptocurrencyAddressTag",
+    humanName: "Cryptocurrency address tag",
+    required: false,
+  },
+  {
+    type: "string",
+    name: "password",
+    humanName: "Test password input",
+    placeholder: "A placeholder for password input...",
+    hint: "Hint for test password input",
+  },
+  {
+    type: "text",
+    name: "a test name",
+    humanName: "Label test input",
+    placeholder: "Test input placeholder...",
+    hint: "Hint for test input (input that matches the last condition)",
+  },
+  {
+    type: "boolean",
+    name: "termsOfUse",
+    terms: [
+      {
+        url: "https://onramper.com/terms-of-use/",
+        humanName: "Onramper's Terms Of Use",
+      },
+      {
+        url: "https://onramper.com/privacy-policy/",
+        humanName: "Onramper's Privacy Policy",
+      },
+      {
+        url:
+          "https://www.notion.so/Transak-Terms-of-Service-6d89598211644402b3be63bc3f1468b4",
+        humanName: "Transak Terms of Service",
+      },
+      {
+        url: "https://onramper.com/privacy-policy/",
+        humanName: "Additional test item added here",
+      },
+    ],
+  },
+];
+
+export default {
+  type: "form",
+  progress: 59,
+  humanName: "Possible form fields",
+  data: allFormFields,
+  url: `${BASE_API}/GoTo/TestGateway/completed/WyJHWHVZZGVBb1B6SF9JcXJWQXh6R3ZRLS0iLDEwMCwiRVVSIiwiQlRDIiwiY3JlZGl0Q2FyZCJd`,
+};

--- a/iframe/src/mocks/responses/steps/TestGateway/steps.ts
+++ b/iframe/src/mocks/responses/steps/TestGateway/steps.ts
@@ -1,60 +1,49 @@
 import { BASE_API } from "../../../constants";
+import possibleFormFieldsStep from "./possibleFomStepFields";
 
 const firstStep = {
-	type: "form",
-	humanName: "Your Details",
-	url: `${BASE_API}/transaction/TestGateway/email/WyJHWHVZZGVBb1B6SF9JcXJWQXh6R3ZRLS0iLDEwMCwiRVVSIiwiQlRDIiwiY3JlZGl0Q2FyZCJd`,
-	title: "Your details",
-	useHeading: true,
-	data: [
-		{
-			type: "string",
-			name: "cryptocurrencyAddress",
-			humanName: "Cryptocurrency wallet address",
-			placeholder: "e.g 3FZbgi29cpjq2GjdwV8eyHuJJnkLtktZc5",
-		},
-		{
-			type: "string",
-			name: "fullname",
-			humanName: "Full name",
-			placeholder: "e.g JohnDoe",
-		},
-		{
-			type: "integer",
-			name: "phoneCountryCode",
-			humanName: "Phone country code",
-		},
-		{
-			type: "integer",
-			name: "phoneNumber",
-			humanName: "Phone number",
-			placeholder: "654 56 84 56",
-		},
-	],
+  type: "form",
+  progress: 30,
+  humanName: "Your Details",
+  url: `${BASE_API}/GoTo/TestGateway/emailStep/WyJHWHVZZGVBb1B6SF9JcXJWQXh6R3ZRLS0iLDEwMCwiRVVSIiwiQlRDIiwiY3JlZGl0Q2FyZCJd`,
+  title: "Your details",
+  useHeading: true,
+  data: [
+    {
+      type: "string",
+      name: "cryptocurrencyAddress",
+      humanName: "Cryptocurrency wallet address",
+      placeholder: "e.g 3FZbgi29cpjq2GjdwV8eyHuJJnkLtktZc5",
+    },
+    {
+      type: "string",
+      name: "fullname",
+      humanName: "Full name",
+      placeholder: "e.g JohnDoe",
+    },
+    {
+      type: "integer",
+      name: "phoneCountryCode",
+      humanName: "Phone country code",
+    },
+    {
+      type: "integer",
+      name: "phoneNumber",
+      humanName: "Phone number",
+      placeholder: "654 56 84 56",
+    },
+  ],
 };
 
-const emailStep = {
-	type: "redirect",
-	url: `${BASE_API}/transaction/TestGateway/verifyEmail/key`,
-	data: [
-		{
-			type: "string",
-			name: "email",
-			humanName: "Email",
-			hint: "You can also find the payment info in your email.",
-		}
-	],
-};
-
-const nextStep: {[key:string]: any} = {
-	firstStep,
-	emailStep
+const nextStep: { [key: string]: any } = {
+  firstStep, 
+  completed: { type: "completed", progress: 99, trackingUrl: "/" }
 };
 
 const getNextStep = (currentStep: string) => {
-	return nextStep?.[currentStep];
+  return nextStep?.[currentStep] || possibleFormFieldsStep;
 };
 
 export default {
-	getNextStep
+  getNextStep,
 };

--- a/iframe/src/mocks/responses/steps/TestGateway/steps.ts
+++ b/iframe/src/mocks/responses/steps/TestGateway/steps.ts
@@ -37,7 +37,7 @@ const firstStep = {
 
 const nextStep: { [key: string]: any } = {
   firstStep, 
-  completed: { type: "completed", progress: 99, trackingUrl: "/" }
+  completed: { type: "completed", progress: 100, trackingUrl: "/" }
 };
 
 const getNextStep = (currentStep: string) => {

--- a/package/src/ApiContext/api/types/nextStep.ts
+++ b/package/src/ApiContext/api/types/nextStep.ts
@@ -77,7 +77,7 @@ interface InfoDepositBankAccount {
 }
 
 type NextStep =
-    { useHeading?: boolean, title?: string } & (FileStep
+    { useHeading?: boolean, title?: string, progress?: number } & (FileStep
     | {
         type: 'information';
         url?: string;

--- a/package/src/common/Header/ProgressHeader/ProgressHeader.models.ts
+++ b/package/src/common/Header/ProgressHeader/ProgressHeader.models.ts
@@ -1,5 +1,5 @@
 export type ProgressHeaderProps = {
-    percentValue: number;
+    percentage: number;
     title?: string;
     useBackButton?: boolean;
     onMenuClick?: () => {}

--- a/package/src/common/Header/ProgressHeader/ProgressHeader.tsx
+++ b/package/src/common/Header/ProgressHeader/ProgressHeader.tsx
@@ -36,7 +36,7 @@ const ProgressHeader: React.FC<ProgressHeaderProps> = (props) => {
 
       <div
         className={classes["progress-bar"]}
-        style={{ width: `${props.percentValue}%` }}
+        style={{ width: `${props.percentage}%` }}
       ></div>
     </nav>
   );

--- a/package/src/common/Header/index.tsx
+++ b/package/src/common/Header/index.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 import styles from "./styles.module.css";
 
 import IconMenu from "../../icons/menu.svg";
-import IconLeftArrow from "../../icons/arrow-left.svg";
+import {ReactComponent as IconLeftArrow} from "../../icons/arrow-left.svg";
 import IconClose from "../../icons/close-menu.svg";
 
 import { NavContext } from "../../NavContext";
@@ -34,11 +34,9 @@ const Header: React.FC<HeaderType> = (props) => {
       } ${props.secondaryTitle ? styles["header--secondary"] : ""}`}
     >
       {backButton && (
-        <img
+        <IconLeftArrow 
+          className={`${styles.header__child}`} 
           onClick={() => backScreen()}
-          className={`${styles.header__child} ${styles["header__back-icon"]}`}
-          alt="Back"
-          src={IconLeftArrow}
         />
       )}
       <span

--- a/package/src/common/Input/InputButton/InputButton.module.css
+++ b/package/src/common/Input/InputButton/InputButton.module.css
@@ -22,6 +22,7 @@
     letter-spacing: 0.01em;
     color: var(--text-dark-color);
     margin-bottom: 12px;
+    white-space: nowrap;
 }
 
 .input-wrapper {

--- a/package/src/steps/FormView/BodyFormView.tsx
+++ b/package/src/steps/FormView/BodyFormView.tsx
@@ -7,7 +7,6 @@ import InputCryptoAddr from '../../common/Input/InputCryptoAddr'
 import ButtonAction from '../../common/ButtonAction'
 import InputButton from '../../common/Input/InputButton/InputButton'
 import InfoBox from '../../common/InfoBox'
-import PickView from '../../PickView'
 import HelpView from '../../common/HelpView'
 import Help2FACreditCard from './renderers/Help2FACreditCard'
 
@@ -46,8 +45,6 @@ type BodyFormViewType = {
     onErrorDismissClick: (field?: string) => void
     heading?: string
 }
-
-// TODO: add separtor to form view ; add temporary input as a component for testing
 
 const BodyFormView: React.FC<BodyFormViewType> = (props) => {
     const { handleInputChange, onActionButton, fields = [] } = props
@@ -296,7 +293,7 @@ const BodyFormView: React.FC<BodyFormViewType> = (props) => {
                                     error={errorObj?.[field.name]}
                                     onClick={
                                         () => nextScreen(
-                                            <PickView
+                                            <OverlayPicker
                                                 title={field.humanName}
                                                 name={field.name}
                                                 onItemClick={(name, index, item) => {
@@ -318,7 +315,7 @@ const BodyFormView: React.FC<BodyFormViewType> = (props) => {
                                     error={errorObj?.[field.name]}
                                     onClick={
                                         () => nextScreen(
-                                            <PickView
+                                            <OverlayPicker
                                                 title={field.humanName}
                                                 name={field.name}
                                                 onItemClick={(name, index, item) => {
@@ -340,7 +337,7 @@ const BodyFormView: React.FC<BodyFormViewType> = (props) => {
                                     error={errorObj?.[field.name]}
                                     onClick={
                                         () => nextScreen(
-                                            <PickView
+                                            <OverlayPicker
                                                 title={field.humanName}
                                                 name={field.name}
                                                 onItemClick={(name, index, item) => {
@@ -359,7 +356,7 @@ const BodyFormView: React.FC<BodyFormViewType> = (props) => {
                                 collected.country === 'us' || collected.country === 'ca'
                                     ? <InputButton ref={inputRefs[i].ref} key={i} className={stylesCommon["body-form-child"]} onClick={
                                         () => nextScreen(
-                                            <PickView
+                                            <OverlayPicker
                                                 title={field.humanName}
                                                 name={field.name}
                                                 onItemClick={(name, index, item) => {

--- a/package/src/steps/FormView/BodyFormView.tsx
+++ b/package/src/steps/FormView/BodyFormView.tsx
@@ -47,6 +47,8 @@ type BodyFormViewType = {
     heading?: string
 }
 
+// TODO: add separtor to form view ; add temporary input as a component for testing
+
 const BodyFormView: React.FC<BodyFormViewType> = (props) => {
     const { handleInputChange, onActionButton, fields = [] } = props
     const { collected, apiInterface } = useContext(APIContext);
@@ -382,14 +384,16 @@ const BodyFormView: React.FC<BodyFormViewType> = (props) => {
                                     : <React.Fragment key={i}></React.Fragment>
                             )) || ((GroupFieldsController.isGroupRequired(field.name, CREDIT_CARD_FIELDS_NAME_GROUP, fields.map((f) => f.name))) && (
                                 !GroupFieldsController.isGroupAdded(CREDIT_CARD_FIELDS_NAME_GROUP)
-                                    ? <CreditCardInput
-                                        fieldsGroup={groupedFieldDataCC}
-                                        ref={inputRefs[i].ref}
-                                        ccNumberValue={collected.ccNumber}
-                                        ccMonthValue={collected.ccMonth}
-                                        ccYearValue={collected.ccYear}
-                                        ccCVVValue={collected.ccCVV}
-                                        key={i} handleInputChange={onChange} errorObj={errorObj} />
+                                    ? <div key={i} className={`${stylesCommon["body-form-child"]}`}>
+                                        <CreditCardInput
+                                            fieldsGroup={groupedFieldDataCC}
+                                            ref={inputRefs[i].ref}
+                                            ccNumberValue={collected.ccNumber}
+                                            ccMonthValue={collected.ccMonth}
+                                            ccYearValue={collected.ccYear}
+                                            ccCVVValue={collected.ccCVV}
+                                            key={i} handleInputChange={onChange} errorObj={errorObj} />
+                                        </div>
                                     : <React.Fragment key={i}></React.Fragment>
                             )) || ((GroupFieldsController.isGroupRequired(field.name, PHONE_NUMBER_FIELDS_NAME_GROUP, fields.map((f) => f.name))) && (
                                 !GroupFieldsController.isGroupAdded(PHONE_NUMBER_FIELDS_NAME_GROUP)

--- a/package/src/steps/FormView/index.tsx
+++ b/package/src/steps/FormView/index.tsx
@@ -112,8 +112,7 @@ const FormView: React.FC<{ nextStep: NextStep & { type: 'form' } }> = ({ nextSte
 
   return (
     <div className={styles.view}>
-      {/* TODO: percentage value should be dynamic */}
-      <ProgressHeader percentValue={30} title={!useHeading ? title : undefined} useBackButton />
+      <ProgressHeader percentage={nextStep.progress || 0} title={!useHeading ? title : undefined} useBackButton />
       <BodyForm
         fields={nextStepData}
         onActionButton={handleButtonAction}


### PR DESCRIPTION
I've put together input fields I could find from server, and other means.
While doing that I found some spacing issues which I fixed, had the opportunity to replace the PickScreen with the overlay selection-list from redesign and observe each instance.

I've added a new mock request `/GoTo/{GatewayName}/{stepName}` and an object for mapping gatewayName to gateway's proccessStep object, this helps moving to the next screen without hussle. 
The new screen is alway the antepenultimate result (acts as a fallback, and provides a link to the complete screen, which is the last screen thanks to this)

Also noted some existing issues and innefieciencies, in the notion file 
https://www.notion.so/onramper/Form-View-5a0c490a1368421a835c52f71b16940b
(adnoted to an existing story about refactoring formview)

Note: the input 'state' is displayed only for us country so please add "?country=us" on to have it displayed