### PR TITLE
Add language parameter for i18n

### DIFF
--- a/iframe/src/App.tsx
+++ b/iframe/src/App.tsx
@@ -28,6 +28,7 @@ const excludeFiat = getArrayParam("excludeFiat");
 const onlyGateways = getArrayParam("onlyGateways");
 const onlyFiat = getArrayParam("onlyFiat");
 const country = getParam("country");
+const language = getParam("language");
 const isAddressEditable = getParam("isAddressEditable");
 const wallets = getWalletsParam();
 const displayChatBubble = getParam("displayChatBubble", "false");
@@ -83,6 +84,7 @@ function App() {
               onlyFiat: onlyFiat,
             }}
             country={country}
+            language={language}
             isAddressEditable={
               isAddressEditable === undefined
                 ? undefined

--- a/package/src/ApiContext/api/index.ts
+++ b/package/src/ApiContext/api/index.ts
@@ -14,6 +14,10 @@ import { t } from "i18next"
 // Note: custom headers most be allowed by the preflight checks, make sure to add them to `access-control-allow-headers` corsPreflight on the server
 const headers = new Headers();
 
+const getAcceptLanguageHeader = () => {
+    return headers.get('Accept-Language');
+}
+
 // Accept-Language header is set here for i18n. The backend will use this to set the language of the responses.
 const updateAcceptLanguageHeader = () => {
     const currentLanguage = i18n.language;

--- a/package/src/ApiContext/index.tsx
+++ b/package/src/ApiContext/index.tsx
@@ -88,19 +88,6 @@ function updateLanguageIfRequired(language: string) {
     API.updateAcceptLanguageHeader();
 }
 
-// Remnants of expanded i18n implementation
-// /**
-//  * Given the country will check if the language of the widget should be changed based on its current language and the
-//  * default language for the provided country.
-//  *
-//  * @param country The Alpha-2 ISO 3166 country code. E.g. 'JP'. See:
-//  * https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
-//  */
-// function updateLanguageByCountryIfRequired(country?: string) {
-//   const widgetsLanguage = getDefaultLanguageForCountry(country);
-//   updateLanguageIfRequired(widgetsLanguage);
-// }
-
 const APIProvider: React.FC<APIProviderType> = (props) => {
   const { t } = useTranslation();
 
@@ -249,11 +236,6 @@ const APIProvider: React.FC<APIProviderType> = (props) => {
 
       if (explicitLanguage)
         updateLanguageIfRequired(explicitLanguage);
-      // Remnants of expanded i18n implementation
-      // else if (actualCountry)
-      //   /* If undefined this shouldn't be triggered as that would reset the language back to the default. We don't want
-      //    * that because then the language change triggered below after the gateway call will be reverted. */
-      //   updateLanguageByCountryIfRequired(actualCountry);
 
       // REQUEST AVAILABLE GATEWAYS
       let rawResponseGateways: GatewaysResponse;
@@ -281,13 +263,6 @@ const APIProvider: React.FC<APIProviderType> = (props) => {
         actualCountry ||
         responseGateways.localization.country || // This is the CloudFront country from the backend.
         DEFAULT_COUNTRY;
-
-      // Remnants of expanded i18n implementation
-      // /* If the country retrieved from the backend response is different then the `actualCountry` then the language
-      //  * should be adjusted. One instance when this occurs is when no country query parameter is provided and our
-      //  * backend detects the user's location by the CloudFront country and sends it back to the widget. */
-      // if (!explicitLanguage && actualCountry !== widgetsCountry)
-      //   updateLanguageByCountryIfRequired(widgetsCountry);
 
       handleInputChange("selectedCountry", widgetsCountry);
       if (

--- a/package/src/ApiContext/index.tsx
+++ b/package/src/ApiContext/index.tsx
@@ -84,8 +84,8 @@ interface APIProviderType {
 function updateLanguageIfRequired(language: string) {
   if (i18n.language !== language)
     i18n.changeLanguage(language);
-  if (API.getAcceptLanguageHeader() !== language)
-    API.updateAcceptLanguageHeader();
+  if (API.getAcceptLanguageParameter() !== language)
+    API.updateAcceptLanguageParameter();
 }
 
 const APIProvider: React.FC<APIProviderType> = (props) => {

--- a/package/src/ApiContext/utils/languages.ts
+++ b/package/src/ApiContext/utils/languages.ts
@@ -3,7 +3,7 @@ const countryLanguagePairings: {[key: string]: string} = {
     KR: 'ko',
     // Undefined countries will use the default language defined below.
 };
-const defaultLanguageForUndefinedCountries = 'en';
+export const defaultLanguage = 'en';
 
 /**
  * Will return the code for the default language spoken in the provided country.
@@ -13,9 +13,10 @@ const defaultLanguageForUndefinedCountries = 'en';
  * @returns The ISO 639-1 language code. E.g. 'ja'. See: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
  */
 export function getDefaultLanguageForCountry(country?: string) {
-    return countryLanguagePairings[country ? country.toUpperCase() : ''] ?? defaultLanguageForUndefinedCountries;
+    return countryLanguagePairings[country ? country.toUpperCase() : ''] ?? defaultLanguage;
 }
 
+// A list of the languages supported by Onramper currently (in the ISO 639-1 language code format).
 export const supportedLanguages: string[] = [...new Set(Object.values(countryLanguagePairings))]
 
 /**

--- a/package/src/ApiContext/utils/languages.ts
+++ b/package/src/ApiContext/utils/languages.ts
@@ -17,7 +17,7 @@ export function getDefaultLanguageForCountry(country?: string) {
 }
 
 // A list of the languages supported by Onramper currently (in the ISO 639-1 language code format).
-export const supportedLanguages: string[] = [...new Set(Object.values(countryLanguagePairings))]
+export const supportedLanguages: string[] = [...new Set(Object.values(countryLanguagePairings)).add(defaultLanguage)]
 
 /**
  * Returns whether the language provided is supported by the i18n implementation.

--- a/package/src/ApiContext/utils/languages.ts
+++ b/package/src/ApiContext/utils/languages.ts
@@ -15,3 +15,15 @@ const defaultLanguageForUndefinedCountries = 'en';
 export function getDefaultLanguageForCountry(country?: string) {
     return countryLanguagePairings[country ? country.toUpperCase() : ''] ?? defaultLanguageForUndefinedCountries;
 }
+
+export const supportedLanguages: string[] = [...new Set(Object.values(countryLanguagePairings))]
+
+/**
+ * Returns whether the language provided is supported by the i18n implementation.
+ *
+ * @param language The ISO 639-1 language code. E.g. 'ja'. See: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+ * @returns A boolean indicating whether or not the widget has i18n support for the language
+ */
+export function isLanguageSupported(language: string) {
+    return supportedLanguages.includes(language);
+}

--- a/package/src/i18n/setup.ts
+++ b/package/src/i18n/setup.ts
@@ -1,6 +1,7 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-import LanguageDetector from 'i18next-browser-languagedetector';
+// Remnants of expanded i18n implementation
+// import LanguageDetector from 'i18next-browser-languagedetector';
 import resources from './translations';
 
 /* i18n was set up using the following guide:
@@ -12,7 +13,8 @@ import resources from './translations';
  * Add `?lng=LANGUAGE` to URL to set language. See `translations.ts` for the available languages.
  */
 i18n
-  .use(LanguageDetector)
+  // Remnants of expanded i18n implementation
+  // .use(LanguageDetector)
   .use(initReactI18next)
   .init({
     debug: false,

--- a/package/src/i18n/setup.ts
+++ b/package/src/i18n/setup.ts
@@ -1,7 +1,5 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-// Remnants of expanded i18n implementation
-// import LanguageDetector from 'i18next-browser-languagedetector';
 import resources from './translations';
 
 /* i18n was set up using the following guide:
@@ -13,8 +11,6 @@ import resources from './translations';
  * Add `?lng=LANGUAGE` to URL to set language. See `translations.ts` for the available languages.
  */
 i18n
-  // Remnants of expanded i18n implementation
-  // .use(LanguageDetector)
   .use(initReactI18next)
   .init({
     debug: false,

--- a/package/src/i18n/setup.ts
+++ b/package/src/i18n/setup.ts
@@ -1,5 +1,6 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+import { defaultLanguage } from '../ApiContext/utils/languages';
 import resources from './translations';
 
 /* i18n was set up using the following guide:
@@ -9,12 +10,14 @@ import resources from './translations';
  * i18next options: https://www.i18next.com/overview/configuration-options
  *
  * Add `?lng=LANGUAGE` to URL to set language. See `translations.ts` for the available languages.
+ *
+ * Note: the language detector has been (temporarily) disabled.
  */
 i18n
   .use(initReactI18next)
   .init({
     debug: false,
-    fallbackLng: 'en',
+    fallbackLng: defaultLanguage,
     interpolation: {
       escapeValue: false,
     },

--- a/package/src/index.tsx
+++ b/package/src/index.tsx
@@ -41,9 +41,6 @@ const OnramperWidget: React.FC<OnramperWidgetProps> = (props) => {
   useEffect(() => {
     if (props.language && isLanguageSupported(props.language))
       i18n.changeLanguage(props.language);
-    // Remnants of expanded i18n implementation
-    // else if (props.country)
-    //   i18n.changeLanguage(getDefaultLanguageForCountry(props.country));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/package/src/index.tsx
+++ b/package/src/index.tsx
@@ -14,6 +14,7 @@ import "./isolateinheritance.css";
 import "./normalize.min.css";
 import './i18n/setup';
 import { useTranslation } from "react-i18next";
+import { isLanguageSupported } from "./ApiContext/utils/languages";
 
 type OnramperWidgetProps = Omit<APIProviderType, "themeColor"> & {
   color?: string;
@@ -36,9 +37,13 @@ const OnramperWidget: React.FC<OnramperWidgetProps> = (props) => {
     "--primary-color": color,
     "--font-family": fontFamily,
   } as React.CSSProperties;
-  
+
   useEffect(() => {
-    props.country && i18n.changeLanguage(props.country);
+    if (props.language && isLanguageSupported(props.language))
+      i18n.changeLanguage(props.language);
+    // Remnants of expanded i18n implementation
+    // else if (props.country)
+    //   i18n.changeLanguage(getDefaultLanguageForCountry(props.country));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -69,6 +74,7 @@ const OnramperWidget: React.FC<OnramperWidgetProps> = (props) => {
             defaultPaymentMethod={props.defaultPaymentMethod}
             filters={props.filters}
             country={props.country}
+            language={props.language}
             isAddressEditable={props.isAddressEditable}
             themeColor={color.slice(1)}
             displayChatBubble={props.displayChatBubble}

--- a/package/src/index.tsx
+++ b/package/src/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import ReactDOM from "react-dom";
 import BuyCryptoView from "./BuyCryptoView";
 import ErrorView from "./common/ErrorView";
@@ -13,8 +13,6 @@ import { on, EVENTS } from "./Onramper";
 import "./isolateinheritance.css";
 import "./normalize.min.css";
 import './i18n/setup';
-import { useTranslation } from "react-i18next";
-import { isLanguageSupported } from "./ApiContext/utils/languages";
 
 type OnramperWidgetProps = Omit<APIProviderType, "themeColor"> & {
   color?: string;
@@ -25,7 +23,6 @@ type OnramperWidgetProps = Omit<APIProviderType, "themeColor"> & {
 
 const OnramperWidget: React.FC<OnramperWidgetProps> = (props) => {
   const [flagRestart, setFlagRestart] = React.useState(0);
-  const { i18n } = useTranslation();
 
   const {
     color = "#266678",
@@ -37,12 +34,6 @@ const OnramperWidget: React.FC<OnramperWidgetProps> = (props) => {
     "--primary-color": color,
     "--font-family": fontFamily,
   } as React.CSSProperties;
-
-  useEffect(() => {
-    if (props.language && isLanguageSupported(props.language))
-      i18n.changeLanguage(props.language);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return (
     <div


### PR DESCRIPTION
Use:
Provide `language=ja` or `language=ko` as query parameters to set the language to Japanese or Korean. The backend response will automatically adjust as well.