### PR TITLE
Features/404/486 payment review data integration

### DIFF
--- a/iframe/src/mocks/responses/steps/TestGateway/steps.ts
+++ b/iframe/src/mocks/responses/steps/TestGateway/steps.ts
@@ -1,9 +1,18 @@
 import { BASE_API } from "../../../constants";
 import possibleFormFieldsStep from "./possibleFomStepFields";
 
-const firstStep = {
-  type: "form",
+const paymentReviewStep = {
+  type: "paymentReview",
   progress: 30,
+  useHeading: true,
+  title: "Review Payment",
+  description: "Please verify the details below carefully",
+  url: `${BASE_API}/GoTo/TestGateway/personalInfoStep/WyJHWHVZZGVBb1B6SF9JcXJWQXh6R3ZRLS0iLDEwMCwiRVVSIiwiQlRDIiwiY3JlZGl0Q2FyZCJd`,
+}
+
+const personalInfoStep = {
+  type: "form",
+  progress: 40,
   humanName: "Your Details",
   url: `${BASE_API}/GoTo/TestGateway/emailStep/WyJHWHVZZGVBb1B6SF9JcXJWQXh6R3ZRLS0iLDEwMCwiRVVSIiwiQlRDIiwiY3JlZGl0Q2FyZCJd`,
   title: "Your details",
@@ -29,7 +38,8 @@ const firstStep = {
 };
 
 const nextStep: { [key: string]: any } = {
-  firstStep, 
+  firstStep: paymentReviewStep,
+  personalInfoStep, 
   completed: { type: "completed", progress: 100, trackingUrl: "/" }
 };
 

--- a/package/src/ApiContext/api/index.ts
+++ b/package/src/ApiContext/api/index.ts
@@ -104,7 +104,7 @@ const tob64 = async (file: File): Promise<string | ArrayBuffer | null> => {
 
 const executeStep = async (step: NextStep, data: { [key: string]: any } | File, params?: ExecuteStepParams): Promise<NextStep> => {
 
-    if (step.type !== 'information' && step.type !== 'form' && step.type !== 'file' && step.type !== 'wait') throw new Error('Unexpected error: Invalid step end.')
+    if (step.type !== 'paymentReview' && step.type !== 'information' && step.type !== 'form' && step.type !== 'file' && step.type !== 'wait') throw new Error('Unexpected error: Invalid step end.')
     if (step.url === undefined) throw new Error('Unexpected error: Invalid step end.')
 
     const isMoonpay = isMoonpayStep(step.url)

--- a/package/src/ApiContext/api/types/nextStep.ts
+++ b/package/src/ApiContext/api/types/nextStep.ts
@@ -83,8 +83,21 @@ interface InfoDepositBankAccount {
     accountAddress: string;
 }
 
+type NextStepBase = { 
+    useHeading?: boolean;
+    title?: string;
+    progress?: number;
+    humanName?: string;
+    description?: string;
+}
+
+type PaymentReviewStep = {
+    type: "paymentReview",
+    url?: string;
+}
+
 type NextStep =
-    { useHeading?: boolean, title?: string, progress?: number } & (FileStep
+    NextStepBase & (FileStep
     | {
         type: 'information';
         url?: string;
@@ -94,19 +107,16 @@ type NextStep =
         type: 'form';
         url: string;
         data: StepDataItems;
-        humanName?: string; // TODO: force all forms to have humanName
         hint?: string;
     } | {
         type: 'iframe';
         url: string;
         fullscreen: boolean;
         neededFeatures?: string;
-        humanName?: string; // TODO: force all forms to have humanName
     } | {
         type: 'redirect';
         url: string;
         hint?: string;
-        humanName?: string; // TODO: force all forms to have humanName
     } | {
         type: 'wait';
         url: string;
@@ -124,7 +134,7 @@ type NextStep =
         depositBankAccount: InfoDepositBankAccount;
         reference: string;
         hint: string;
-    });
+    } | PaymentReviewStep);
 
 interface FieldError {
     field: string

--- a/package/src/ChooseGatewayView/styles.module.css
+++ b/package/src/ChooseGatewayView/styles.module.css
@@ -95,7 +95,7 @@
 
 .option-badges-wrapper {
     display: flex;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
 }
 
 .badge-wrapper {
@@ -136,7 +136,6 @@
 .option-right-sub {
     display: flex;
     justify-content: flex-end;
-    align-items: center;
     flex-wrap: wrap;
     overflow: hidden;
     height: 40px;

--- a/package/src/common/Header/ProgressHeader/ProgressHeader.models.ts
+++ b/package/src/common/Header/ProgressHeader/ProgressHeader.models.ts
@@ -1,5 +1,5 @@
 export type ProgressHeaderProps = {
-    percentage: number;
+    percentage?: number;
     title?: string;
     useBackButton?: boolean;
     onMenuClick?: () => {}

--- a/package/src/common/Header/ProgressHeader/ProgressHeader.tsx
+++ b/package/src/common/Header/ProgressHeader/ProgressHeader.tsx
@@ -36,7 +36,7 @@ const ProgressHeader: React.FC<ProgressHeaderProps> = (props) => {
 
       <div
         className={classes["progress-bar"]}
-        style={{ width: `${props.percentage}%` }}
+        style={{ width: `${props.percentage || 0}%` }}
       ></div>
     </nav>
   );

--- a/package/src/common/Heading/Heading.module.css
+++ b/package/src/common/Heading/Heading.module.css
@@ -1,10 +1,27 @@
-h1.wrapper {
+.wrapper > h1, 
+.wrapper > h2 {
     display: block;
-    padding-top: 12px;
-    padding-bottom: 37px;
     text-align: center;
-    font-weight: 600;
-    font-size: 20px;
-    line-height: 24px;
-    color: var(--text-dark-color);
+}
+
+.wrapper > h1 {
+  font-weight: 600;
+  font-size: 20px;
+  line-height: 24px;
+  color: var(--text-dark-color);
+}
+
+.wrapper > h2 {
+  font-size: 14px;
+  line-height: 23px;
+  color: var(--text-light-color);
+}
+
+.wrapper {
+  padding-top: var(--pt-heading);
+  padding-bottom: var(--pb-heading);
+}
+
+.wrapper > h1 + h2 {
+    padding-top: 10px;
 }

--- a/package/src/common/Heading/Heading.tsx
+++ b/package/src/common/Heading/Heading.tsx
@@ -2,11 +2,17 @@ import React from "react";
 import classes from "./Heading.module.css";
 import commonClasses from "../../styles.module.css";
 
-const Heading: React.FC<{text: string}> = (props) => {
+const Heading: React.FC<{text?: string, textSubHeading?: string; className?: string}> = (props) => {
     return (
-      <h1 className={`${commonClasses["remove-default"]} ${classes["wrapper"]}`}>
-          {props.text}
-      </h1>
+      <div className={`${classes["wrapper"]} ${props.className || ""}`}>
+        {!!props.text && <h1 className={`${commonClasses["remove-default"]}`}>
+            {props.text}
+        </h1>}
+
+        {props.textSubHeading && <h2 className={`${commonClasses["remove-default"]}`}>
+          {props.textSubHeading}
+        </h2>}
+      </div>
     );
   };
 

--- a/package/src/steps/ConfirmPaymentView/BodyConfirmPayment.tsx
+++ b/package/src/steps/ConfirmPaymentView/BodyConfirmPayment.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import stylesCommon from '../../styles.module.css'
 import styles from './styles.module.css'
 
@@ -12,6 +12,8 @@ import { CSSTransition } from 'react-transition-group';
 
 import ButtonAction from '../../common/ButtonAction'
 import Footer from '../../common/Footer'
+import Heading from '../../common/Heading/Heading'
+import InfoBox from '../../common/InfoBox'
 
 
 type BodyConfirmPaymentViewType = {
@@ -19,7 +21,6 @@ type BodyConfirmPaymentViewType = {
     payAmount: number
     fees?: number
     currency?: string
-
     cryptoAmount: number
     cryptoDenom: string
     cryptoAddr?: string
@@ -27,18 +28,31 @@ type BodyConfirmPaymentViewType = {
     paymentMethod?: string
     cryptoIcon?: string
     txTime?: { seconds: number, message: string }
-    isFilled?: boolean
     conversionRate?: number
+    heading?: string;
+    subHeading?: string;
+    errorMessage?: string;
+    isLoading?: boolean;
 }
 
 const BodyConfirmPaymentView: React.FC<BodyConfirmPaymentViewType> = (props) => {
     const [isExpanded, setIsExpanded] = useState(false)
-    const transitionRef = React.useRef(null)
-    const { onActionButton } = props
+    const transitionRef = React.useRef(null);
+    
+    const [errorControlMsg, setErrorControlMsg] = useState<string>();
+    useEffect(() => {
+        setErrorControlMsg(props.errorMessage);
+    }, [props.errorMessage]);
 
     return (
         <main className={stylesCommon.body}>
+            <InfoBox type='error' in={!!errorControlMsg} className={`${stylesCommon.body__child}`} canBeDismissed onDismissClick={() => setErrorControlMsg(undefined)}>
+                {errorControlMsg}
+            </InfoBox>
+
             <div className={`${stylesCommon.body__child} ${stylesCommon.grow} ${styles.container}`}>
+                {(props.heading || props.subHeading) && <Heading text={props.heading} textSubHeading={props.subHeading} /> }
+
                 <ul className={`${styles.wrapper}`}>
                     <Item type='main' icon={<IconPay className={styles.icon} />} title='Pay' content={`${props.payAmount} ${props.currency}`} onClick={props.conversionRate || props.fees ? () => setIsExpanded(actual => !actual) : undefined} isExpanded={isExpanded} />
                     <CSSTransition
@@ -83,7 +97,11 @@ const BodyConfirmPaymentView: React.FC<BodyConfirmPaymentViewType> = (props) => 
                 {/* <label className={styles['terms']}><input type="checkbox" name='agreementCheckbox' onChange={(e) => inputInterface.handleInputChange(e.currentTarget.name, e.currentTarget.checked)} /> I accept the gateway's privacy policy, transaction policy and terms of use and Onramper's privacy policy and terms of use.</label> */}
             </div>
             <div className={`${stylesCommon.body__child}`}>
-                <ButtonAction onClick={onActionButton} text='Continue' disabled={!props.isFilled} />
+                <ButtonAction
+                    onClick={props.onActionButton}
+                    text={props.isLoading ? "Loading..." : "Continue"}
+                    disabled={!!props.isLoading}
+                />
                 <Footer />  
             </div>
         </main >

--- a/package/src/steps/ConfirmPaymentView/PaymentReview.models.ts
+++ b/package/src/steps/ConfirmPaymentView/PaymentReview.models.ts
@@ -1,0 +1,7 @@
+import { NextStep } from "../../ApiContext";
+
+export type PaymentReviewProps = {
+  nextStep: NextStep;
+  includeCryptoAddr?: boolean;
+  onButtonAction?: () => void;
+};

--- a/package/src/steps/ConfirmPaymentView/PaymentReviewDecorator.tsx
+++ b/package/src/steps/ConfirmPaymentView/PaymentReviewDecorator.tsx
@@ -1,0 +1,34 @@
+import React, { useContext } from "react";
+import Step from "../Step";
+
+import { NavContext } from "../../NavContext";
+import { PaymentReviewProps } from "./PaymentReview.models";
+import { NextStep } from "../../ApiContext";
+import ConfirmPaymentView from ".";
+
+/**
+ * serves as backwards compatibility for older functionality: the PaymentReviewStep injected by the frontend before a specific step
+ * Ex. Server sends form step as the first step of Wyre. 
+ *     The frontend has some logic that indicates if in this case it ought to display the 'Payment review' screen, 
+ *     and if so the first step from the server will be displayed after the user presses 'continue'
+ */
+
+const injectedStep = {
+  type: "paymentReview",
+  progress: 30,
+  useHeading: true,
+  title: "Review Payment",
+  description: "Please verify the details below carefully",
+} as NextStep;
+
+const PaymentReviewDecorator: React.FC<PaymentReviewProps> = (props) => {
+  const { nextScreen } = useContext(NavContext);
+
+  const onButtonAction = () => {
+    nextScreen(<Step nextStep={props.nextStep} isConfirmed />);
+  };
+
+  return <ConfirmPaymentView {...props} onButtonAction={onButtonAction} nextStep={injectedStep} />;
+};
+
+export default PaymentReviewDecorator;

--- a/package/src/steps/ConfirmPaymentView/index.tsx
+++ b/package/src/steps/ConfirmPaymentView/index.tsx
@@ -1,55 +1,78 @@
-import React, { useContext } from "react";
-import Header from "../../common/Header";
+import React, { useCallback, useContext, useState } from "react";
 import BodyConfirmPayment from "./BodyConfirmPayment";
 import styles from "../../styles.module.css";
 import Step from "../Step";
 
 import { NavContext } from "../../NavContext";
-import { APIContext, NextStep } from "../../ApiContext";
+import { APIContext } from "../../ApiContext";
+import ProgressHeader from "../../common/Header/ProgressHeader/ProgressHeader";
+import ErrorView from "../../common/ErrorView";
+import { PaymentReviewProps } from "./PaymentReview.models";
 
-const ConfirmPaymentView: React.FC<{
-  nextStep: NextStep;
-  includeCryptoAddr?: boolean;
-}> = (props) => {
+const ConfirmPaymentView: React.FC<PaymentReviewProps> = (props) => {
   const { nextScreen } = useContext(NavContext);
   const { collected } = useContext(APIContext);
-  const [walletAddr, setWalletAddr] = React.useState<
-    undefined | { address?: string; memo?: string }
-  >({
+  
+  const [walletAddr, setWalletAddr] = React.useState<undefined | { address?: string; memo?: string } >({
     address: collected.cryptocurrencyAddress?.address,
     memo: collected.cryptocurrencyAddress?.memo,
   });
+  const [cryptoAmount] = useState(
+    collected.amountInCrypto ? collected.amount : (collected.selectedGateway?.receivedCrypto || 0)
+  );
+  const [payAmount] = useState(
+    collected.amountInCrypto ? (collected.selectedGateway?.receivedCrypto || 0) : collected.amount
+  );
+
+  const [isLoading, setIsLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string>()
+  const { apiInterface } = useContext(APIContext);
+
+  const onButtonAction = useCallback(async () => {
+    if(props.onButtonAction) {
+      props.onButtonAction();
+      return;
+    }
+
+    setIsLoading(true);
+    setErrorMessage(undefined);
+    try {
+      const newNextStep = await apiInterface.executeStep(props.nextStep, {});
+      nextScreen(<Step nextStep={newNextStep} />);
+    } catch (_error) {
+      const error = _error as { fatal: any, message: string };
+      if (error.fatal) {
+        nextScreen(<ErrorView />);
+        return;
+      }
+      setErrorMessage(error.message);
+    }
+    setIsLoading(false);
+  }, [apiInterface, nextScreen, props])
 
   React.useEffect(() => {
-    setWalletAddr(
-      props.includeCryptoAddr
-        ? {
-            address: collected.cryptocurrencyAddress?.address,
-            memo: collected.cryptocurrencyAddress?.memo,
-          }
-        : undefined
-    );
+    const walletAddress = props.includeCryptoAddr ? {
+        address: collected.cryptocurrencyAddress?.address,
+        memo: collected.cryptocurrencyAddress?.memo,
+      }
+    : undefined;
+
+    setWalletAddr(walletAddress);
   }, [props.includeCryptoAddr, collected.cryptocurrencyAddress]);
 
   return (
     <div className={styles.view}>
-      <Header title="Payment review" backButton />
+      <ProgressHeader
+        percentage={props.nextStep.progress}
+        title={!props.nextStep.useHeading ? props.nextStep.title : undefined}
+        useBackButton
+      />
       <BodyConfirmPayment
-        onActionButton={() =>
-          nextScreen(<Step nextStep={props.nextStep} isConfirmed />)
-        }
-        payAmount={
-          collected.amountInCrypto
-            ? collected.selectedGateway?.receivedCrypto || 0
-            : collected.amount
-        }
+        onActionButton={onButtonAction}
+        payAmount={payAmount}
         fees={collected.selectedGateway?.fees}
         currency={collected.selectedCurrency?.name}
-        cryptoAmount={
-          collected.amountInCrypto
-            ? collected.amount
-            : collected.selectedGateway?.receivedCrypto || 0
-        }
+        cryptoAmount={cryptoAmount}
         cryptoDenom={collected.selectedCrypto?.name || ""}
         txTime={collected.selectedGateway?.duration}
         cryptoAddr={walletAddr?.address}
@@ -57,7 +80,10 @@ const ConfirmPaymentView: React.FC<{
         cryptoIcon={collected.selectedCrypto?.icon}
         paymentMethod={collected.selectedPaymentMethod?.name}
         conversionRate={collected.selectedGateway?.rate}
-        isFilled={true}
+        heading={props.nextStep.useHeading ? props.nextStep.title : undefined}
+        subHeading={props.nextStep.description}
+        errorMessage={errorMessage}
+        isLoading={isLoading}
       />
     </div>
   );

--- a/package/src/steps/FormView/index.tsx
+++ b/package/src/steps/FormView/index.tsx
@@ -112,7 +112,7 @@ const FormView: React.FC<{ nextStep: NextStep & { type: 'form' } }> = ({ nextSte
 
   return (
     <div className={styles.view}>
-      <ProgressHeader percentage={nextStep.progress || 0} title={!useHeading ? title : undefined} useBackButton />
+      <ProgressHeader percentage={nextStep.progress} title={!useHeading ? title : undefined} useBackButton />
       <BodyForm
         fields={nextStepData}
         onActionButton={handleButtonAction}

--- a/package/src/steps/Step/StepViewContent.tsx
+++ b/package/src/steps/Step/StepViewContent.tsx
@@ -3,7 +3,7 @@ import stylesCommon from "../../styles.module.css";
 
 import ErrorVisual from "../../common/ErrorVisual";
 
-import ConfirmPaymentView from "../ConfirmPaymentView";
+import PaymentReview from "../ConfirmPaymentView";
 import UploadView from "../UploadView";
 import PickOptionView from "../PickOptionView";
 import FormView from "../FormView";
@@ -17,6 +17,7 @@ import { NavContext } from "../../NavContext";
 import { APIContext, NextStep } from "../../ApiContext";
 import InformationView from "../InformationView";
 import Footer from "../../common/Footer";
+import PaymentReviewDecorator from "../ConfirmPaymentView/PaymentReviewDecorator";
 
 export interface NewStepProps {
   nextStep?: NextStep;
@@ -53,13 +54,30 @@ const StepViewContent: React.FC<NewStepProps> = ({ nextStep, isConfirmed }) => {
           );
       }
       replaceScreen(
-        <ConfirmPaymentView
+        <PaymentReviewDecorator
           nextStep={nextStep}
           includeCryptoAddr={includeAddr}
         />
       );
       return;
     }
+
+    const showPaymentReview = () => {
+      if (!collected.isAddressEditable) {
+        const newAddress =
+          collected.defaultAddrs[collected.selectedCrypto?.id ?? ""];
+          
+        inputInterface.handleInputChange("cryptocurrencyAddress", newAddress);
+      }
+
+      replaceScreen(
+        <PaymentReview
+          nextStep={nextStep}
+          includeCryptoAddr={true}
+        />
+      );
+    }
+
     switch (nextStep.type) {
       case "form":
         replaceScreen(<FormView nextStep={nextStep} />);
@@ -77,16 +95,19 @@ const StepViewContent: React.FC<NewStepProps> = ({ nextStep, isConfirmed }) => {
         replaceScreen(<WaitView nextStep={nextStep} />);
         break;
       case "completed":
-        replaceScreen(<SuccessView txType="instant" nextStep={nextStep} />); //onlyScreen(<SuccessView txType='instant' />)
+        replaceScreen(<SuccessView txType="instant" nextStep={nextStep} />);
         break;
       case "iframe":
         replaceScreen(<IframeView nextStep={nextStep} />);
         break;
       case "requestBankTransaction":
-        replaceScreen(<WireTranserView nextStep={nextStep} />); //onlyScreen(<WireTranserView nextStep={nextStep} />)
+        replaceScreen(<WireTranserView nextStep={nextStep} />);
         break;
       case "information":
         replaceScreen(<InformationView nextStep={nextStep} />);
+        break;
+      case "paymentReview":
+        showPaymentReview();
         break;
       default:
         break;

--- a/package/src/steps/UploadView/index.tsx
+++ b/package/src/steps/UploadView/index.tsx
@@ -25,7 +25,8 @@ const UploadView: React.FC<{ nextStep: NextStep & { type: 'file' } }> = (props) 
     try {
       const newNextStep = await apiInterface.executeStep(props.nextStep, file);
       nextScreen(<Step nextStep={newNextStep} />)
-    } catch (error) {
+    } catch (_error) {
+      const error = _error as { fatal: any, message: string };
       if (error.fatal) {
         nextScreen(<ErrorView />)
         return

--- a/package/src/styles.module.css
+++ b/package/src/styles.module.css
@@ -28,6 +28,8 @@ theme styles
     --padding-top: 1.25rem;
     --padding-rl: 35px;
     --padding-bottom: 1.125rem;
+    --pt-heading: 12px;
+    --pb-heading: 35px;
     /* header */
     --header-height: 82px;
     --header-tabs-height: 63px;
@@ -269,7 +271,8 @@ components
     opacity: 0.5;
 }
 
-h1.remove-default {
+h1.remove-default,
+h2.remove-default {
     margin: 0;
     padding: 0;
     font-size: 1em;


### PR DESCRIPTION
Added mock data and support for a new step: "paymentReview" (navigation between steps, and headings)
The screen already exists but was not used like a step, so I needed to keep some backwards compatibility. 
More info on this is present following the below link:
[https://www.notion.so/onramper/Step-picker-eb96d2b8b3b74ba991839e21d780fb47](https://www.notion.so/onramper/Step-picker-eb96d2b8b3b74ba991839e21d780fb47)


