### PR TITLE
WT-18: changed email address of support

### DIFF
--- a/package/src/steps/PopupView/index.tsx
+++ b/package/src/steps/PopupView/index.tsx
@@ -57,7 +57,7 @@ const PopupView: React.FC<{
         reportError(event.data, false, event.data);
       } else {
         reportError(
-          "Unknown error. Please, contact help@onramper.com and provide the following info: " +
+          "Unknown error. Please, contact support@onramper.com and provide the following info: " +
             nextStep.url,
           false,
           event.data


### PR DESCRIPTION
Changed all instances of help@onramper to support@onramper.com in the widget codebase.